### PR TITLE
fix : remove the class spaced-section on fwx-image-banner

### DIFF
--- a/sections/fireworkx-image-banner.liquid
+++ b/sections/fireworkx-image-banner.liquid
@@ -22,7 +22,7 @@
 {
   "name": "Fireworkx Image Banner",
   "tag": "section",
-  "class": "spaced-section spaced-section--full-width",
+  "class": "spaced-section--full-width",
   "settings": [
     {
       "type": "image_picker",


### PR DESCRIPTION
Fixing the margin Issue on the Home page banner 

Fixes #0.

- Removed a class on the section that was responsible for the styling change 


**Demo links**
 - http://127.0.0.1:9292/?
 - https://andycab.co.za/?_ab=0&_fd=0&_sc=1

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
